### PR TITLE
Prohibit first statement in query from being a "not"

### DIFF
--- a/src/Resin.UnitTests/QueryParserTests.cs
+++ b/src/Resin.UnitTests/QueryParserTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Resin.Analysis;
 using Resin.Querying;
 

--- a/src/Resin.UnitTests/QueryParserTests.cs
+++ b/src/Resin.UnitTests/QueryParserTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Resin.Analysis;
 using Resin.Querying;
 
@@ -93,6 +94,14 @@ namespace Tests
             var q = new QueryParser(new Analyzer(), 0.5f).Parse("title:was up~ subtitle:in da house");
 
             Assert.AreEqual("+title:was~ title:up~ subtitle:in subtitle:da subtitle:house", q.ToString());
+        }
+
+        [TestMethod]
+        public void Should_prohibit_not_as_first_word()
+        {
+            var q = new QueryParser(new Analyzer()).Parse("NOT title:rambo");
+
+            Assert.AreEqual(null, q);
         }
     }
 }

--- a/src/ResinCore/Querying/QueryParser.cs
+++ b/src/ResinCore/Querying/QueryParser.cs
@@ -20,6 +20,7 @@ namespace Resin.Querying
         public QueryContext Parse(string query)
         {
             if (string.IsNullOrWhiteSpace(query)) throw new ArgumentException("query");
+            if (query.StartsWith("NOT", StringComparison.OrdinalIgnoreCase)) return null;
 
             // http://stackoverflow.com/questions/521146/c-sharp-split-string-but-keep-split-chars-separators
 


### PR DESCRIPTION
Fix for issue:
Prohibit first statement in query from being a "not" statement but allow all other query operators

https://github.com/kreeben/resin/issues/9