### PR TITLE
Remove hardcoded path separator. 

### DIFF
--- a/src/Sir.HttpServer/ServiceConfiguration.cs
+++ b/src/Sir.HttpServer/ServiceConfiguration.cs
@@ -28,7 +28,7 @@ namespace Sir.HttpServer
             // register plugin startup and teardown handlers
 
 #if DEBUG
-            assemblyPath = Path.Combine(assemblyPath, "bin\\Debug\\netcoreapp2.1");
+            assemblyPath = Path.Combine(assemblyPath, "bin", "Debug", "netcoreapp2.1");
 #endif
 
             var files = Directory.GetFiles(assemblyPath, "*.plugin.dll");


### PR DESCRIPTION
UNIX based system use different path separator. To make it cross-platform, I have removed the hardcoded path separator and used Path.combine to join the paths.